### PR TITLE
简化调试名称设置

### DIFF
--- a/src/ZenithEngine.DirectX12/DXDescriptorAllocator.cs
+++ b/src/ZenithEngine.DirectX12/DXDescriptorAllocator.cs
@@ -71,7 +71,6 @@ internal unsafe class DXDescriptorAllocator : GraphicsResource
 
     protected override void DebugName(string name)
     {
-        Heap.SetName(name).ThrowIfError();
     }
 
     protected override void Destroy()

--- a/src/ZenithEngine.DirectX12/DXFence.cs
+++ b/src/ZenithEngine.DirectX12/DXFence.cs
@@ -38,7 +38,6 @@ internal unsafe class DXFence : GraphicsResource
 
     protected override void DebugName(string name)
     {
-        Fence.SetName(name).ThrowIfError();
     }
 
     protected override void Destroy()

--- a/src/ZenithEngine.Vulkan/VKBuffer.cs
+++ b/src/ZenithEngine.Vulkan/VKBuffer.cs
@@ -98,8 +98,6 @@ internal unsafe class VKBuffer : Buffer
     protected override void DebugName(string name)
     {
         Context.SetDebugName(ObjectType.Buffer, Buffer.Handle, name);
-
-        DeviceMemory.Name = $"{name} DeviceMemory";
     }
 
     protected override void Destroy()

--- a/src/ZenithEngine.Vulkan/VKDescriptorPool.cs
+++ b/src/ZenithEngine.Vulkan/VKDescriptorPool.cs
@@ -122,7 +122,6 @@ internal unsafe class VKDescriptorPool : GraphicsResource
 
     protected override void DebugName(string name)
     {
-        Context.SetDebugName(ObjectType.DescriptorPool, Pool.Handle, name);
     }
 
     protected override void Destroy()

--- a/src/ZenithEngine.Vulkan/VKDeviceMemory.cs
+++ b/src/ZenithEngine.Vulkan/VKDeviceMemory.cs
@@ -47,7 +47,6 @@ internal unsafe class VKDeviceMemory : GraphicsResource
 
     protected override void DebugName(string name)
     {
-        Context.SetDebugName(ObjectType.DeviceMemory, DeviceMemory.Handle, name);
     }
 
     protected override void Destroy()

--- a/src/ZenithEngine.Vulkan/VKFence.cs
+++ b/src/ZenithEngine.Vulkan/VKFence.cs
@@ -42,7 +42,6 @@ internal unsafe class VKFence : GraphicsResource
 
     protected override void DebugName(string name)
     {
-        Context.SetDebugName(ObjectType.Fence, Fence.Handle, name);
     }
 
     protected override void Destroy()

--- a/src/ZenithEngine.Vulkan/VKFrameBuffer.cs
+++ b/src/ZenithEngine.Vulkan/VKFrameBuffer.cs
@@ -226,15 +226,6 @@ internal unsafe class VKFrameBuffer : FrameBuffer
 
     protected override void DebugName(string name)
     {
-        for (uint i = 0; i < ColorAttachmentCount; i++)
-        {
-            Context.SetDebugName(ObjectType.ImageView, colorViews[i].Handle, $"{name} Color Target[{i}]");
-        }
-
-        if (HasDepthStencilAttachment)
-        {
-            Context.SetDebugName(ObjectType.ImageView, depthStencilView.Handle, $"{name} Depth Stencil Target");
-        }
     }
 
     protected override void Destroy()

--- a/src/ZenithEngine.Vulkan/VKTexture.cs
+++ b/src/ZenithEngine.Vulkan/VKTexture.cs
@@ -191,12 +191,6 @@ internal unsafe class VKTexture : Texture
     protected override void DebugName(string name)
     {
         Context.SetDebugName(ObjectType.Image, Image.Handle, name);
-        Context.SetDebugName(ObjectType.ImageView, ImageView.Handle, name);
-
-        if (DeviceMemory is not null)
-        {
-            DeviceMemory.Name = $"{name} DeviceMemory";
-        }
     }
 
     protected override void Destroy()


### PR DESCRIPTION
简化调试名称设置

移除了多个文件中与调试名称相关的代码行，以减少不必要的调试信息设置和避免重复设置设备内存名称。这些更改包括：

- 在 `DXDescriptorAllocator.cs` 和 `DXFence.cs` 中移除了 `SetName` 调用。
- 在 `VKBuffer.cs` 中移除了设备内存名称的设置。
- 在 `VKDescriptorPool.cs`、`VKDeviceMemory.cs` 和 `VKFence.cs` 中移除了调试名称设置。
- 在 `VKFrameBuffer.cs` 中移除了与颜色和深度模板附件相关的调试名称设置。
- 在 `VKTexture.cs` 中移除了与图像视图和设备内存名称相关的设置。