### PR TITLE
整理代码。

### DIFF
--- a/src/Examples/Common/VisualTest.cs
+++ b/src/Examples/Common/VisualTest.cs
@@ -10,8 +10,10 @@ namespace Common;
 
 public abstract unsafe class VisualTest
 {
-    protected VisualTest(string name, Backend backend)
+    protected VisualTest(string name)
     {
+        const Backend backend = Backend.Vulkan;
+
         Window = WindowController.CreateWindow(name, 1270, 720);
 
         CameraController = new(Window);

--- a/src/Examples/ComputeShader/Assets/Shaders/Shader.hlsl
+++ b/src/Examples/ComputeShader/Assets/Shaders/Shader.hlsl
@@ -8,6 +8,8 @@ struct Constants
 };
 
 ConstantBuffer<Constants> constants : register(b0, space0);
+
+[[vk::image_format("rgba8")]]
 RWTexture2D<float4> Output : register(u0, space0);
 
 float mod(float x, float y)

--- a/src/Examples/ComputeShader/ComputeShaderTest.cs
+++ b/src/Examples/ComputeShader/ComputeShaderTest.cs
@@ -10,7 +10,7 @@ using Buffer = ZenithEngine.Common.Graphics.Buffer;
 
 namespace ComputeShader;
 
-internal unsafe class ComputeShaderTest(Backend backend) : VisualTest("Compute Shader Test", backend)
+internal unsafe class ComputeShaderTest() : VisualTest("Compute Shader Test")
 {
     [StructLayout(LayoutKind.Explicit)]
     private struct Constants

--- a/src/Examples/ComputeShader/Program.cs
+++ b/src/Examples/ComputeShader/Program.cs
@@ -1,11 +1,3 @@
-﻿using ZenithEngine.Common.Enums;
+﻿using ComputeShader;
 
-namespace ComputeShader;
-
-internal static class Program
-{
-    private static void Main(string[] _)
-    {
-        new ComputeShaderTest(Backend.DirectX12).Run();
-    }
-}
+new ComputeShaderTest().Run();

--- a/src/Examples/PlatformDetection/Program.cs
+++ b/src/Examples/PlatformDetection/Program.cs
@@ -1,36 +1,28 @@
 ﻿using ZenithEngine.Common.Enums;
 using ZenithEngine.Common.Graphics;
 
-namespace PlatformDetection;
-
-internal static class Program
+foreach (Backend backend in Enum.GetValues<Backend>())
 {
-    private static void Main(string[] _)
+    DetectPlatform(backend);
+}
+
+static void DetectPlatform(Backend backend)
+{
+    Console.WriteLine($"Backend: {backend}");
+
+    try
     {
-        foreach (Backend backend in Enum.GetValues<Backend>())
-        {
-            DetectPlatform(backend);
-        }
+        using GraphicsContext context = GraphicsContext.Create(backend);
+        context.CreateDevice();
+
+        Console.WriteLine($"    Device: {context.Capabilities.DeviceName}");
+        Console.WriteLine($"    Ray Query: {context.Capabilities.IsRayQuerySupported}");
+        Console.WriteLine($"    Ray Tracing: {context.Capabilities.IsRayTracingSupported}");
+        Console.WriteLine();
     }
-
-    private static void DetectPlatform(Backend backend)
+    catch (Exception)
     {
-        Console.WriteLine($"Backend: {backend}");
-
-        try
-        {
-            using GraphicsContext context = GraphicsContext.Create(backend);
-            context.CreateDevice();
-
-            Console.WriteLine($"    Device: {context.Capabilities.DeviceName}");
-            Console.WriteLine($"    Ray Query: {context.Capabilities.IsRayQuerySupported}");
-            Console.WriteLine($"    Ray Tracing: {context.Capabilities.IsRayTracingSupported}");
-            Console.WriteLine();
-        }
-        catch (Exception)
-        {
-            Console.WriteLine("    Failed to create device.");
-            Console.WriteLine();
-        }
+        Console.WriteLine("    Failed to create device.");
+        Console.WriteLine();
     }
 }

--- a/src/Examples/RayTracing/Assets/Shaders/Shader.hlsl
+++ b/src/Examples/RayTracing/Assets/Shaders/Shader.hlsl
@@ -72,6 +72,8 @@ StructuredBuffer<Vertex> VertexBuffers[4] : register(t1, space0);
 StructuredBuffer<uint> IndexBuffers[4] : register(t5, space0);
 StructuredBuffer<Material> Materials : register(t9, space0);
 ConstantBuffer<Global> Global : register(b0, space0);
+
+[[vk::image_format("rgba8")]]
 RWTexture2D<float4> Output : register(u0, space0);
 
 Vertex GetVertex(uint geometryIndex, uint primitiveIndex, float3 barycentrics)

--- a/src/Examples/RayTracing/Program.cs
+++ b/src/Examples/RayTracing/Program.cs
@@ -1,11 +1,3 @@
-﻿using ZenithEngine.Common.Enums;
+﻿using RayTracing;
 
-namespace RayTracing;
-
-internal static class Program
-{
-    private static void Main(string[] _)
-    {
-        new RayTracingTest(Backend.Vulkan).Run();
-    }
-}
+new RayTracingTest().Run();

--- a/src/Examples/RayTracing/Program.cs
+++ b/src/Examples/RayTracing/Program.cs
@@ -6,6 +6,6 @@ internal static class Program
 {
     private static void Main(string[] _)
     {
-        new RayTracingTest(Backend.DirectX12).Run();
+        new RayTracingTest(Backend.Vulkan).Run();
     }
 }

--- a/src/Examples/RayTracing/RayTracingTest.cs
+++ b/src/Examples/RayTracing/RayTracingTest.cs
@@ -12,7 +12,7 @@ using ResourceSet = ZenithEngine.Common.Graphics.ResourceSet;
 
 namespace RayTracing;
 
-internal unsafe class RayTracingTest(Backend backend) : VisualTest("RayTracing Test", backend)
+internal unsafe class RayTracingTest() : VisualTest("RayTracing Test")
 {
     [StructLayout(LayoutKind.Explicit)]
     private struct Camera

--- a/src/Examples/Triangle/Program.cs
+++ b/src/Examples/Triangle/Program.cs
@@ -1,11 +1,3 @@
-﻿using ZenithEngine.Common.Enums;
+﻿using Triangle;
 
-namespace Triangle;
-
-internal static class Program
-{
-    private static void Main(string[] _)
-    {
-        new TriangleTest(Backend.DirectX12).Run();
-    }
-}
+new TriangleTest().Run();

--- a/src/Examples/Triangle/TriangleTest.cs
+++ b/src/Examples/Triangle/TriangleTest.cs
@@ -9,7 +9,7 @@ using Buffer = ZenithEngine.Common.Graphics.Buffer;
 
 namespace Triangle;
 
-internal unsafe class TriangleTest(Backend backend) : VisualTest("Triangle Test", backend)
+internal unsafe class TriangleTest() : VisualTest("Triangle Test")
 {
     [StructLayout(LayoutKind.Explicit)]
     private struct Constants

--- a/src/ZenithEngine.DirectX12/DXCommandBuffer.cs
+++ b/src/ZenithEngine.DirectX12/DXCommandBuffer.cs
@@ -744,11 +744,6 @@ internal unsafe class DXCommandBuffer : CommandBuffer
 
     private void ValidatePipeline<T>(out T pipeline) where T : Pipeline
     {
-        if (activePipeline is null)
-        {
-            throw new ZenithEngineException("The pipeline is not bound.");
-        }
-
         if (activePipeline is not T castedPipeline)
         {
             throw new ZenithEngineException(ExceptionHelpers.NotSupported(activePipeline));

--- a/src/ZenithEngine.DirectX12/DXFormats.cs
+++ b/src/ZenithEngine.DirectX12/DXFormats.cs
@@ -104,6 +104,22 @@ internal static class DXFormats
         };
     }
 
+    public static Format GetSwapChainFormat(PixelFormat format)
+    {
+        return format switch
+        {
+            PixelFormat.R8G8B8A8UNorm or
+            PixelFormat.R8G8B8A8UNormSRgb => Format.FormatR8G8B8A8Unorm,
+
+            PixelFormat.R16G16B16A16Float => Format.FormatR16G16B16A16Float,
+
+            PixelFormat.B8G8R8A8UNorm or
+            PixelFormat.B8G8R8A8UNormSRgb => Format.FormatB8G8R8A8Unorm,
+
+            _ => throw new ZenithEngineException(ExceptionHelpers.NotSupported(format))
+        };
+    }
+
     public static SampleDesc GetSampleDesc(TextureSampleCount count)
     {
         return count switch

--- a/src/ZenithEngine.DirectX12/DXSwapChain.cs
+++ b/src/ZenithEngine.DirectX12/DXSwapChain.cs
@@ -87,7 +87,7 @@ internal unsafe class DXSwapChain : SwapChain
         {
             Width = size.X,
             Height = size.Y,
-            Format = DXFormats.GetFormat(Desc.ColorTargetFormat),
+            Format = DXFormats.GetSwapChainFormat(Desc.ColorTargetFormat),
             SampleDesc = new(1, 0),
             BufferUsage = DXGI.UsageRenderTargetOutput,
             BufferCount = BufferCount,

--- a/src/ZenithEngine.ShaderCompiler/IncludeHandler.cs
+++ b/src/ZenithEngine.ShaderCompiler/IncludeHandler.cs
@@ -30,19 +30,17 @@ internal unsafe class IncludeHandler(Func<string, string>? includeHandler) : Com
         {
             string shader = self.Handler.Invoke(Utils.PtrToStringUni(pFileName));
 
-            if (string.IsNullOrEmpty(shader))
+            if (!string.IsNullOrEmpty(shader))
             {
-                throw new ZenithEngineException($"Include file '{fileName}' contains no data.");
+                byte[] source = Encoding.UTF8.GetBytes(shader);
+
+                DxcCompiler.DxcUtils.CreateBlob(in source[0],
+                                                (uint)source.Length,
+                                                DXC.CPUtf8,
+                                                (IDxcBlobEncoding**)&blob);
+
+                self.IncludeCache.Add(fileName, blob);
             }
-
-            byte[] source = Encoding.UTF8.GetBytes(shader);
-
-            DxcCompiler.DxcUtils.CreateBlob(in source[0],
-                                            (uint)source.Length,
-                                            DXC.CPUtf8,
-                                            (IDxcBlobEncoding**)&blob);
-
-            self.IncludeCache.Add(fileName, blob);
         }
 
         *includeSourceBlob = blob.QueryInterface<IDxcBlob>();

--- a/src/ZenithEngine.Vulkan/VKBottomLevelAS.cs
+++ b/src/ZenithEngine.Vulkan/VKBottomLevelAS.cs
@@ -61,7 +61,7 @@ internal unsafe class VKBottomLevelAS : BottomLevelAS
                     Triangles = new()
                     {
                         SType = StructureType.AccelerationStructureGeometryTrianglesDataKhr,
-                        VertexFormat = VKFormats.GetPixelFormat(triangles.VertexFormat),
+                        VertexFormat = VKFormats.GetFormat(triangles.VertexFormat),
                         VertexData = new()
                         {
                             DeviceAddress = triangles.VertexBuffer.VK().Address + triangles.VertexOffsetInBytes

--- a/src/ZenithEngine.Vulkan/VKCommandBuffer.cs
+++ b/src/ZenithEngine.Vulkan/VKCommandBuffer.cs
@@ -806,11 +806,6 @@ internal unsafe class VKCommandBuffer : CommandBuffer
 
     private void ValidatePipeline<T>(out T pipeline) where T : Pipeline
     {
-        if (activePipeline is null)
-        {
-            throw new ZenithEngineException("The pipeline is not bound.");
-        }
-
         if (activePipeline is not T castedPipeline)
         {
             throw new ZenithEngineException(ExceptionHelpers.NotSupported(activePipeline));

--- a/src/ZenithEngine.Vulkan/VKDebug.cs
+++ b/src/ZenithEngine.Vulkan/VKDebug.cs
@@ -87,7 +87,9 @@ internal unsafe class VKDebug : GraphicsResource
             DebugUtilsMessengerCreateInfoEXT createInfo = new()
             {
                 SType = StructureType.DebugUtilsMessengerCreateInfoExt,
-                MessageSeverity = DebugUtilsMessageSeverityFlagsEXT.WarningBitExt
+                MessageSeverity = DebugUtilsMessageSeverityFlagsEXT.VerboseBitExt
+                                  | DebugUtilsMessageSeverityFlagsEXT.InfoBitExt
+                                  | DebugUtilsMessageSeverityFlagsEXT.WarningBitExt
                                   | DebugUtilsMessageSeverityFlagsEXT.ErrorBitExt,
                 MessageType = DebugUtilsMessageTypeFlagsEXT.GeneralBitExt
                               | DebugUtilsMessageTypeFlagsEXT.ValidationBitExt
@@ -108,9 +110,11 @@ internal unsafe class VKDebug : GraphicsResource
             DebugReportCallbackCreateInfoEXT createInfo = new()
             {
                 SType = StructureType.DebugReportCallbackCreateInfoExt,
-                Flags = DebugReportFlagsEXT.WarningBitExt
+                Flags = DebugReportFlagsEXT.InformationBitExt
+                        | DebugReportFlagsEXT.WarningBitExt
                         | DebugReportFlagsEXT.PerformanceWarningBitExt
-                        | DebugReportFlagsEXT.ErrorBitExt,
+                        | DebugReportFlagsEXT.ErrorBitExt
+                        | DebugReportFlagsEXT.DebugBitExt,
                 PfnCallback = pfnReportCallback
             };
 
@@ -208,6 +212,8 @@ internal unsafe class VKDebug : GraphicsResource
 
         PrintMessage(stringBuilder.ToString(), messageSeverity switch
         {
+            DebugUtilsMessageSeverityFlagsEXT.VerboseBitExt => ConsoleColor.DarkGray,
+            DebugUtilsMessageSeverityFlagsEXT.InfoBitExt => ConsoleColor.Blue,
             DebugUtilsMessageSeverityFlagsEXT.WarningBitExt => ConsoleColor.Yellow,
             DebugUtilsMessageSeverityFlagsEXT.ErrorBitExt => ConsoleColor.Red,
             _ => Console.ForegroundColor
@@ -249,9 +255,11 @@ internal unsafe class VKDebug : GraphicsResource
 
         PrintMessage(stringBuilder.ToString(), (DebugReportFlagsEXT)flags switch
         {
-            DebugReportFlagsEXT.WarningBitExt or
-            DebugReportFlagsEXT.PerformanceWarningBitExt => ConsoleColor.Yellow,
+            DebugReportFlagsEXT.InformationBitExt => ConsoleColor.Blue,
+            DebugReportFlagsEXT.WarningBitExt => ConsoleColor.Yellow,
+            DebugReportFlagsEXT.PerformanceWarningBitExt => ConsoleColor.DarkYellow,
             DebugReportFlagsEXT.ErrorBitExt => ConsoleColor.Red,
+            DebugReportFlagsEXT.DebugBitExt => ConsoleColor.DarkGray,
             _ => Console.ForegroundColor
         });
 

--- a/src/ZenithEngine.Vulkan/VKDebug.cs
+++ b/src/ZenithEngine.Vulkan/VKDebug.cs
@@ -87,9 +87,7 @@ internal unsafe class VKDebug : GraphicsResource
             DebugUtilsMessengerCreateInfoEXT createInfo = new()
             {
                 SType = StructureType.DebugUtilsMessengerCreateInfoExt,
-                MessageSeverity = DebugUtilsMessageSeverityFlagsEXT.VerboseBitExt
-                                  | DebugUtilsMessageSeverityFlagsEXT.InfoBitExt
-                                  | DebugUtilsMessageSeverityFlagsEXT.WarningBitExt
+                MessageSeverity = DebugUtilsMessageSeverityFlagsEXT.WarningBitExt
                                   | DebugUtilsMessageSeverityFlagsEXT.ErrorBitExt,
                 MessageType = DebugUtilsMessageTypeFlagsEXT.GeneralBitExt
                               | DebugUtilsMessageTypeFlagsEXT.ValidationBitExt
@@ -110,11 +108,9 @@ internal unsafe class VKDebug : GraphicsResource
             DebugReportCallbackCreateInfoEXT createInfo = new()
             {
                 SType = StructureType.DebugReportCallbackCreateInfoExt,
-                Flags = DebugReportFlagsEXT.InformationBitExt
-                        | DebugReportFlagsEXT.WarningBitExt
+                Flags = DebugReportFlagsEXT.WarningBitExt
                         | DebugReportFlagsEXT.PerformanceWarningBitExt
-                        | DebugReportFlagsEXT.ErrorBitExt
-                        | DebugReportFlagsEXT.DebugBitExt,
+                        | DebugReportFlagsEXT.ErrorBitExt,
                 PfnCallback = pfnReportCallback
             };
 
@@ -212,8 +208,6 @@ internal unsafe class VKDebug : GraphicsResource
 
         PrintMessage(stringBuilder.ToString(), messageSeverity switch
         {
-            DebugUtilsMessageSeverityFlagsEXT.VerboseBitExt => ConsoleColor.DarkGray,
-            DebugUtilsMessageSeverityFlagsEXT.InfoBitExt => ConsoleColor.Blue,
             DebugUtilsMessageSeverityFlagsEXT.WarningBitExt => ConsoleColor.Yellow,
             DebugUtilsMessageSeverityFlagsEXT.ErrorBitExt => ConsoleColor.Red,
             _ => Console.ForegroundColor
@@ -255,11 +249,9 @@ internal unsafe class VKDebug : GraphicsResource
 
         PrintMessage(stringBuilder.ToString(), (DebugReportFlagsEXT)flags switch
         {
-            DebugReportFlagsEXT.InformationBitExt => ConsoleColor.Blue,
-            DebugReportFlagsEXT.WarningBitExt => ConsoleColor.Yellow,
-            DebugReportFlagsEXT.PerformanceWarningBitExt => ConsoleColor.DarkYellow,
+            DebugReportFlagsEXT.WarningBitExt or
+            DebugReportFlagsEXT.PerformanceWarningBitExt => ConsoleColor.Yellow,
             DebugReportFlagsEXT.ErrorBitExt => ConsoleColor.Red,
-            DebugReportFlagsEXT.DebugBitExt => ConsoleColor.DarkGray,
             _ => Console.ForegroundColor
         });
 

--- a/src/ZenithEngine.Vulkan/VKDebug.cs
+++ b/src/ZenithEngine.Vulkan/VKDebug.cs
@@ -93,8 +93,7 @@ internal unsafe class VKDebug : GraphicsResource
                                   | DebugUtilsMessageSeverityFlagsEXT.ErrorBitExt,
                 MessageType = DebugUtilsMessageTypeFlagsEXT.GeneralBitExt
                               | DebugUtilsMessageTypeFlagsEXT.ValidationBitExt
-                              | DebugUtilsMessageTypeFlagsEXT.PerformanceBitExt
-                              | DebugUtilsMessageTypeFlagsEXT.DeviceAddressBindingBitExt,
+                              | DebugUtilsMessageTypeFlagsEXT.PerformanceBitExt,
                 PfnUserCallback = pfnUtilsCallback
             };
 

--- a/src/ZenithEngine.Vulkan/VKFormats.cs
+++ b/src/ZenithEngine.Vulkan/VKFormats.cs
@@ -33,7 +33,7 @@ internal static unsafe class VKFormats
         };
     }
 
-    public static Format GetPixelFormat(PixelFormat format)
+    public static Format GetFormat(PixelFormat format)
     {
         return format switch
         {
@@ -105,6 +105,22 @@ internal static unsafe class VKFormats
 
             PixelFormat.D24UNormS8UInt => Format.D24UnormS8Uint,
             PixelFormat.D32FloatS8UInt => Format.D32SfloatS8Uint,
+
+            _ => throw new ZenithEngineException(ExceptionHelpers.NotSupported(format))
+        };
+    }
+
+    public static Format GetSwapChainFormat(PixelFormat format)
+    {
+        return format switch
+        {
+            PixelFormat.R8G8B8A8UNorm => Format.R8G8B8A8Unorm,
+            PixelFormat.R8G8B8A8UNormSRgb => Format.R8G8B8A8Srgb,
+
+            PixelFormat.R16G16B16A16Float => Format.R16G16B16A16Sfloat,
+
+            PixelFormat.B8G8R8A8UNorm => Format.B8G8R8A8Unorm,
+            PixelFormat.B8G8R8A8UNormSRgb => Format.B8G8R8A8Srgb,
 
             _ => throw new ZenithEngineException(ExceptionHelpers.NotSupported(format))
         };
@@ -625,85 +641,6 @@ internal static unsafe class VKFormats
             HitGroupType.Triangles => RayTracingShaderGroupTypeKHR.TrianglesHitGroupKhr,
             HitGroupType.Procedural => RayTracingShaderGroupTypeKHR.ProceduralHitGroupKhr,
             _ => throw new ZenithEngineException(ExceptionHelpers.NotSupported(type))
-        };
-    }
-    #endregion
-
-    #region To ZenithEngine
-    public static PixelFormat GetPixelFormat(Format format)
-    {
-        return format switch
-        {
-            Format.R8Unorm => PixelFormat.R8UNorm,
-            Format.R8SNorm => PixelFormat.R8SNorm,
-            Format.R8Uint => PixelFormat.R8UInt,
-            Format.R8Sint => PixelFormat.R8SInt,
-
-            Format.R16Unorm => PixelFormat.R16UNorm,
-            Format.R16SNorm => PixelFormat.R16SNorm,
-            Format.R16Uint => PixelFormat.R16UInt,
-            Format.R16Sint => PixelFormat.R16SInt,
-            Format.R16Sfloat => PixelFormat.R16Float,
-
-            Format.R32Uint => PixelFormat.R32UInt,
-            Format.R32Sint => PixelFormat.R32SInt,
-            Format.R32Sfloat => PixelFormat.R32Float,
-
-            Format.R8G8Unorm => PixelFormat.R8G8UNorm,
-            Format.R8G8SNorm => PixelFormat.R8G8SNorm,
-            Format.R8G8Uint => PixelFormat.R8G8UInt,
-            Format.R8G8Sint => PixelFormat.R8G8SInt,
-
-            Format.R16G16Unorm => PixelFormat.R16G16UNorm,
-            Format.R16G16SNorm => PixelFormat.R16G16SNorm,
-            Format.R16G16Uint => PixelFormat.R16G16UInt,
-            Format.R16G16Sint => PixelFormat.R16G16SInt,
-            Format.R16G16Sfloat => PixelFormat.R16G16Float,
-
-            Format.R32G32Uint => PixelFormat.R32G32UInt,
-            Format.R32G32Sint => PixelFormat.R32G32SInt,
-            Format.R32G32Sfloat => PixelFormat.R32G32Float,
-
-            Format.R32G32B32Uint => PixelFormat.R32G32B32UInt,
-            Format.R32G32B32Sint => PixelFormat.R32G32B32SInt,
-            Format.R32G32B32Sfloat => PixelFormat.R32G32B32Float,
-
-            Format.R8G8B8A8Unorm => PixelFormat.R8G8B8A8UNorm,
-            Format.R8G8B8A8Srgb => PixelFormat.R8G8B8A8UNormSRgb,
-            Format.R8G8B8A8SNorm => PixelFormat.R8G8B8A8SNorm,
-            Format.R8G8B8A8Uint => PixelFormat.R8G8B8A8UInt,
-            Format.R8G8B8A8Sint => PixelFormat.R8G8B8A8SInt,
-
-            Format.R16G16B16A16Unorm => PixelFormat.R16G16B16A16UNorm,
-            Format.R16G16B16A16SNorm => PixelFormat.R16G16B16A16SNorm,
-            Format.R16G16B16A16Uint => PixelFormat.R16G16B16A16UInt,
-            Format.R16G16B16A16Sint => PixelFormat.R16G16B16A16SInt,
-            Format.R16G16B16A16Sfloat => PixelFormat.R16G16B16A16Float,
-
-            Format.R32G32B32A32Uint => PixelFormat.R32G32B32A32UInt,
-            Format.R32G32B32A32Sint => PixelFormat.R32G32B32A32SInt,
-            Format.R32G32B32A32Sfloat => PixelFormat.R32G32B32A32Float,
-
-            Format.B8G8R8A8Unorm => PixelFormat.B8G8R8A8UNorm,
-            Format.B8G8R8A8Srgb => PixelFormat.B8G8R8A8UNormSRgb,
-
-            Format.BC1RgbaUnormBlock => PixelFormat.BC1UNorm,
-            Format.BC1RgbaSrgbBlock => PixelFormat.BC1UNormSRgb,
-            Format.BC2UnormBlock => PixelFormat.BC2UNorm,
-            Format.BC2SrgbBlock => PixelFormat.BC2UNormSRgb,
-            Format.BC3UnormBlock => PixelFormat.BC3UNorm,
-            Format.BC3SrgbBlock => PixelFormat.BC3UNormSRgb,
-            Format.BC4UnormBlock => PixelFormat.BC4UNorm,
-            Format.BC4SNormBlock => PixelFormat.BC4SNorm,
-            Format.BC5UnormBlock => PixelFormat.BC5UNorm,
-            Format.BC5SNormBlock => PixelFormat.BC5SNorm,
-            Format.BC7UnormBlock => PixelFormat.BC7UNorm,
-            Format.BC7SrgbBlock => PixelFormat.BC7UNormSRgb,
-
-            Format.D24UnormS8Uint => PixelFormat.D24UNormS8UInt,
-            Format.D32SfloatS8Uint => PixelFormat.D32FloatS8UInt,
-
-            _ => throw new ZenithEngineException(ExceptionHelpers.NotSupported(format))
         };
     }
     #endregion

--- a/src/ZenithEngine.Vulkan/VKFrameBuffer.cs
+++ b/src/ZenithEngine.Vulkan/VKFrameBuffer.cs
@@ -251,7 +251,7 @@ internal unsafe class VKFrameBuffer : FrameBuffer
             SType = StructureType.ImageViewCreateInfo,
             Image = texture.Image,
             ViewType = ImageViewType.Type2D,
-            Format = VKFormats.GetPixelFormat(texture.Desc.Format),
+            Format = VKFormats.GetFormat(texture.Desc.Format),
             SubresourceRange = new()
             {
                 AspectMask = VKFormats.GetImageAspectFlags(texture.Desc.Usage),

--- a/src/ZenithEngine.Vulkan/VKGraphicsContext.PhysicalDevice.cs
+++ b/src/ZenithEngine.Vulkan/VKGraphicsContext.PhysicalDevice.cs
@@ -52,11 +52,6 @@ internal unsafe partial class VKGraphicsContext
         uint physicalDeviceCount;
         Vk.EnumeratePhysicalDevices(Instance, &physicalDeviceCount, null).ThrowIfError();
 
-        if (physicalDeviceCount is 0)
-        {
-            throw new ZenithEngineException("No physical devices found.");
-        }
-
         VkPhysicalDevice[] physicalDevices = new VkPhysicalDevice[physicalDeviceCount];
         Vk.EnumeratePhysicalDevices(Instance, &physicalDeviceCount, physicalDevices).ThrowIfError();
 

--- a/src/ZenithEngine.Vulkan/VKGraphicsPipeline.cs
+++ b/src/ZenithEngine.Vulkan/VKGraphicsPipeline.cs
@@ -252,7 +252,7 @@ internal unsafe class VKGraphicsPipeline : GraphicsPipeline
         // Outputs
         {
             uint colorAttachmentCount = (uint)desc.Outputs.ColorAttachments.Length;
-            Format* colorAttachmentFormats = Allocator.Alloc([.. desc.Outputs.ColorAttachments.Select(VKFormats.GetPixelFormat)]);
+            Format* colorAttachmentFormats = Allocator.Alloc([.. desc.Outputs.ColorAttachments.Select(VKFormats.GetFormat)]);
 
             PipelineViewportStateCreateInfo viewportState = new()
             {
@@ -280,7 +280,7 @@ internal unsafe class VKGraphicsPipeline : GraphicsPipeline
 
             if (desc.Outputs.DepthStencilAttachment.HasValue)
             {
-                Format depthStencilAttachmentFormat = VKFormats.GetPixelFormat(desc.Outputs.DepthStencilAttachment.Value);
+                Format depthStencilAttachmentFormat = VKFormats.GetFormat(desc.Outputs.DepthStencilAttachment.Value);
 
                 renderingCreateInfo.DepthAttachmentFormat = depthStencilAttachmentFormat;
                 renderingCreateInfo.StencilAttachmentFormat = depthStencilAttachmentFormat;

--- a/src/ZenithEngine.Vulkan/VKSwapChain.cs
+++ b/src/ZenithEngine.Vulkan/VKSwapChain.cs
@@ -209,12 +209,6 @@ internal unsafe partial class VKSwapChain : SwapChain
                                                            &formatCount,
                                                            null).ThrowIfError();
 
-        SurfaceFormatKHR[] formats = new SurfaceFormatKHR[formatCount];
-        Context.KhrSurface.GetPhysicalDeviceSurfaceFormats(Context.PhysicalDevice,
-                                                           Surface,
-                                                           &formatCount,
-                                                           out formats[0]).ThrowIfError();
-
         uint modeCount;
         Context.KhrSurface.GetPhysicalDeviceSurfacePresentModes(Context.PhysicalDevice,
                                                                 Surface,
@@ -244,8 +238,8 @@ internal unsafe partial class VKSwapChain : SwapChain
             SType = StructureType.SwapchainCreateInfoKhr,
             Surface = Surface,
             MinImageCount = desiredImages,
-            ImageFormat = ChooseSwapSurfaceFormat(formats).Format,
-            ImageColorSpace = ChooseSwapSurfaceFormat(formats).ColorSpace,
+            ImageFormat = VKFormats.GetSwapChainFormat(Desc.ColorTargetFormat),
+            ImageColorSpace = ColorSpaceKHR.SpaceSrgbNonlinearKhr,
             ImageExtent = ChooseSwapExtent(capabilities),
             ImageArrayLayers = 1,
             ImageUsage = ImageUsageFlags.ColorAttachmentBit,
@@ -262,8 +256,7 @@ internal unsafe partial class VKSwapChain : SwapChain
                                               out Swapchain).ThrowIfError();
 
         swapChainFrameBuffer.CreateFrameBuffers(createInfo.ImageExtent.Width,
-                                                createInfo.ImageExtent.Height,
-                                                createInfo.ImageFormat);
+                                                createInfo.ImageExtent.Height);
     }
 
     private void AcquireNextImage()
@@ -298,21 +291,6 @@ internal unsafe partial class VKSwapChain : SwapChain
         swapChainFrameBuffer.DestroyFrameBuffers();
 
         Context.KhrSwapchain!.DestroySwapchain(Context.Device, Swapchain, null);
-    }
-
-    private SurfaceFormatKHR ChooseSwapSurfaceFormat(SurfaceFormatKHR[] surfaceFormats)
-    {
-        Format desiredFormat = VKFormats.GetPixelFormat(Desc.ColorTargetFormat);
-
-        foreach (SurfaceFormatKHR availableFormat in surfaceFormats)
-        {
-            if (availableFormat.Format == desiredFormat && availableFormat.ColorSpace is ColorSpaceKHR.SpaceSrgbNonlinearKhr)
-            {
-                return availableFormat;
-            }
-        }
-
-        return surfaceFormats[0];
     }
 
     private PresentModeKHR ChooseSwapPresentMode(PresentModeKHR[] presentModes)

--- a/src/ZenithEngine.Vulkan/VKSwapChainFrameBuffer.cs
+++ b/src/ZenithEngine.Vulkan/VKSwapChainFrameBuffer.cs
@@ -1,5 +1,4 @@
-﻿using Silk.NET.Vulkan;
-using ZenithEngine.Common.Descriptions;
+﻿using ZenithEngine.Common.Descriptions;
 using ZenithEngine.Common.Enums;
 using ZenithEngine.Common.Graphics;
 
@@ -16,7 +15,7 @@ internal unsafe class VKSwapChainFrameBuffer(GraphicsContext context,
 
     private new VKGraphicsContext Context => (VKGraphicsContext)base.Context;
 
-    public void CreateFrameBuffers(uint width, uint height, Format imageFormat)
+    public void CreateFrameBuffers(uint width, uint height)
     {
         bool hasDepthStencilAttachment = swapChain.Desc.DepthStencilTargetFormat is not null;
 
@@ -48,7 +47,7 @@ internal unsafe class VKSwapChainFrameBuffer(GraphicsContext context,
         {
             TextureDesc desc = new(width,
                                    height,
-                                   format: VKFormats.GetPixelFormat(imageFormat),
+                                   format: swapChain.Desc.ColorTargetFormat,
                                    usage: TextureUsage.RenderTarget);
 
             colorTargets[i] = new VKTexture(Context, in desc, images[i]);

--- a/src/ZenithEngine.Vulkan/VKTexture.cs
+++ b/src/ZenithEngine.Vulkan/VKTexture.cs
@@ -21,7 +21,7 @@ internal unsafe class VKTexture : Texture
         {
             SType = StructureType.ImageCreateInfo,
             ImageType = VKFormats.GetImageType(desc.Type),
-            Format = VKFormats.GetPixelFormat(desc.Format),
+            Format = VKFormats.GetFormat(desc.Format),
             Extent = new()
             {
                 Width = desc.Width,
@@ -206,7 +206,7 @@ internal unsafe class VKTexture : Texture
             SType = StructureType.ImageViewCreateInfo,
             Image = Image,
             ViewType = VKFormats.GetImageViewType(Desc.Type),
-            Format = VKFormats.GetPixelFormat(Desc.Format),
+            Format = VKFormats.GetFormat(Desc.Format),
             SubresourceRange = new()
             {
                 AspectMask = VKFormats.GetImageAspectFlags(Desc.Usage),


### PR DESCRIPTION
#### PR Classification
代码清理和功能增强。

#### PR Summary
此拉取请求移除了多个类构造函数中的 `Backend` 参数，并重构了 `Program.cs` 中的主方法以直接调用测试类。还添加了新的方法以获取交换链格式，并修复了多个文件中的逻辑和类型问题。
- `VisualTest.cs`: 移除构造函数中的 `Backend` 参数，使用常量创建窗口。
- `Program.cs`: 重构 `Main` 方法以直接调用测试类，移除 `using ZenithEngine.Common.Enums`。
- `DXFormats.cs`: 添加 `GetSwapChainFormat` 方法以获取交换链格式。
- `VKFormats.cs`: 添加 `GetSwapChainFormat` 和 `GetImageUsageFlags` 方法，替换 `GetPixelFormat`。
- `VKSwapChain.cs`: 使用 `GetSwapChainFormat` 替代 `ChooseSwapSurfaceFormat` 的实现。
