### PR TITLE
添加反射机制。

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
         <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.22.0" />
         <PackageVersion Include="Silk.NET.Vulkan.Extensions.MVK" Version="2.22.0" />
         <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.8" />
-        <PackageVersion Include="Slangc.NET" Version="2025.8.1" />
+        <PackageVersion Include="Slangc.NET" Version="2025.8.2-rc.1" />
         <PackageVersion Include="System.Text.Json" Version="9.0.4" />
     </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
         <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.22.0" />
         <PackageVersion Include="Silk.NET.Vulkan.Extensions.MVK" Version="2.22.0" />
         <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.8" />
-        <PackageVersion Include="Slangc.NET" Version="2025.8.2-rc.1" />
+        <PackageVersion Include="Slangc.NET" Version="2025.8.2-rc.2" />
         <PackageVersion Include="System.Text.Json" Version="9.0.4" />
     </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,3 @@ Zenith Engine is a modern, cross-platform graphics rendering engine written in C
 - Delete the `Triangle` project and change it to the `Rasterization` project.
 - `Rasterization` and `RayTracing` use the Cornell Box model.
 - After the release of Silk.NET 3.0, refactor all interface calls and use the unsafe method.
-
-## Task List
-1. Add reflection feature in `ZenithEngine.ShaderCompiler`.

--- a/src/Examples/ComputeShader/Assets/Shaders/Shader.slang
+++ b/src/Examples/ComputeShader/Assets/Shaders/Shader.slang
@@ -9,7 +9,7 @@ struct Constants
 };
 
 uniform Constants constants;
-uniform RWTexture2D<float4> output;
+uniform RWTexture2D output;
 
 float mod(float x, float y)
 {

--- a/src/Examples/ComputeShader/Assets/Shaders/Shader.slang
+++ b/src/Examples/ComputeShader/Assets/Shaders/Shader.slang
@@ -8,8 +8,8 @@ struct Constants
     float TotalTime;
 };
 
-ConstantBuffer<Constants> constants : register(b0, space0);
-RWTexture2D<float4> Output : register(u0, space0);
+uniform Constants constants;
+uniform RWTexture2D<float4> output;
 
 float mod(float x, float y)
 {
@@ -34,5 +34,5 @@ void Main(uint3 id: SV_DispatchThreadID)
 
     color = tanh(color / 1e2);
 
-    Output[id.xy] = color;
+    output[id.xy] = color;
 }

--- a/src/Examples/ComputeShader/ComputeShaderTest.cs
+++ b/src/Examples/ComputeShader/ComputeShaderTest.cs
@@ -40,8 +40,7 @@ internal unsafe class ComputeShaderTest() : VisualTest("Compute Shader Test")
 
         output = Context.Factory.CreateTexture(in outputDesc);
 
-        ShaderReflection reflection = ShaderReflection.Empty;
-        using Shader csShader = Context.Factory.CompileShader(shader, ShaderStages.Compute, "Main", ref reflection);
+        using Shader csShader = Context.Factory.CompileShader(shader, ShaderStages.Compute, "Main", out ShaderReflection reflection);
 
         ResourceLayoutDesc layoutDesc = new
         (

--- a/src/Examples/ComputeShader/ComputeShaderTest.cs
+++ b/src/Examples/ComputeShader/ComputeShaderTest.cs
@@ -51,13 +51,13 @@ internal unsafe class ComputeShaderTest() : VisualTest("Compute Shader Test")
 
         layout = Context.Factory.CreateResourceLayout(in layoutDesc);
 
-        ResourceSetDesc rsDesc = new(layout, constantsBuffer, output);
+        ResourceSetDesc setDesc = new(layout, constantsBuffer, output);
 
-        set = Context.Factory.CreateResourceSet(in rsDesc);
+        set = Context.Factory.CreateResourceSet(in setDesc);
 
-        ComputePipelineDesc cpDesc = new(csShader, layout);
+        ComputePipelineDesc pipelineDesc = new(csShader, layout);
 
-        pipeline = Context.Factory.CreateComputePipeline(in cpDesc);
+        pipeline = Context.Factory.CreateComputePipeline(in pipelineDesc);
     }
 
     protected override void OnUpdate(double deltaTime, double totalTime)

--- a/src/Examples/ComputeShader/ComputeShaderTest.cs
+++ b/src/Examples/ComputeShader/ComputeShaderTest.cs
@@ -52,7 +52,7 @@ internal unsafe class ComputeShaderTest() : VisualTest("Compute Shader Test")
 
         resourceSet = Context.Factory.CreateResourceSet(in rsDesc);
 
-        using Shader csShader = Context.Factory.CompileShader(shader, ShaderStages.Compute, "Main");
+        using Shader csShader = Context.Factory.CompileShader(shader, ShaderStages.Compute, "Main", out _);
 
         ComputePipelineDesc cpDesc = new(csShader, resourceLayout);
 

--- a/src/Examples/RayTracing/Assets/Shaders/Shader.slang
+++ b/src/Examples/RayTracing/Assets/Shaders/Shader.slang
@@ -72,7 +72,7 @@ uniform StructuredBuffer<Vertex> vertexBuffers[4];
 uniform StructuredBuffer<uint> indexBuffers[4];
 uniform StructuredBuffer<Material> materials;
 uniform Global global;
-uniform RWTexture2D<float4> output;
+uniform RWTexture2D output;
 
 Vertex GetVertex(uint geometryIndex, uint primitiveIndex, float3 barycentrics)
 {

--- a/src/Examples/RayTracing/Assets/Shaders/Shader.slang
+++ b/src/Examples/RayTracing/Assets/Shaders/Shader.slang
@@ -67,12 +67,12 @@ struct AOPayload
     float Value;
 };
 
-RaytracingAccelerationStructure scene : register(t0, space0);
-StructuredBuffer<Vertex> vertexBuffers[4] : register(t1, space0);
-StructuredBuffer<uint> indexBuffers[4] : register(t5, space0);
-StructuredBuffer<Material> materials : register(t9, space0);
-ConstantBuffer<Global> global : register(b0, space0);
-RWTexture2D<float4> output : register(u0, space0);
+uniform RaytracingAccelerationStructure scene;
+uniform StructuredBuffer<Vertex> vertexBuffers[4];
+uniform StructuredBuffer<uint> indexBuffers[4];
+uniform StructuredBuffer<Material> materials;
+uniform Global global;
+uniform RWTexture2D<float4> output;
 
 Vertex GetVertex(uint geometryIndex, uint primitiveIndex, float3 barycentrics)
 {

--- a/src/Examples/RayTracing/RayTracingTest.cs
+++ b/src/Examples/RayTracing/RayTracingTest.cs
@@ -218,11 +218,11 @@ internal unsafe class RayTracingTest() : VisualTest("RayTracing Test")
 
         resSet = Context.Factory.CreateResourceSet(in resSetDesc);
 
-        using Shader rgShader = Context.Factory.CompileShader(shader, ShaderStages.RayGeneration, "RayGenMain");
-        using Shader msShader = Context.Factory.CompileShader(shader, ShaderStages.Miss, "MissMain");
-        using Shader chShader = Context.Factory.CompileShader(shader, ShaderStages.ClosestHit, "ClosestHitMain");
-        using Shader msAoShader = Context.Factory.CompileShader(shader, ShaderStages.Miss, "MissAO");
-        using Shader chAoShader = Context.Factory.CompileShader(shader, ShaderStages.ClosestHit, "ClosestHitAO");
+        using Shader rgShader = Context.Factory.CompileShader(shader, ShaderStages.RayGeneration, "RayGenMain", out _);
+        using Shader msShader = Context.Factory.CompileShader(shader, ShaderStages.Miss, "MissMain", out _);
+        using Shader chShader = Context.Factory.CompileShader(shader, ShaderStages.ClosestHit, "ClosestHitMain", out _);
+        using Shader msAoShader = Context.Factory.CompileShader(shader, ShaderStages.Miss, "MissAO", out _);
+        using Shader chAoShader = Context.Factory.CompileShader(shader, ShaderStages.ClosestHit, "ClosestHitAO", out _);
 
         RayTracingPipelineDesc rtpDesc = new
         (

--- a/src/Examples/RayTracing/RayTracingTest.cs
+++ b/src/Examples/RayTracing/RayTracingTest.cs
@@ -194,12 +194,12 @@ internal unsafe class RayTracingTest() : VisualTest("RayTracing Test")
 
         output = Context.Factory.CreateTexture(in outputDesc);
 
-        ShaderReflection reflection = ShaderReflection.Empty;
-        using Shader rgShader = Context.Factory.CompileShader(shader, ShaderStages.RayGeneration, "RayGenMain", ref reflection);
-        using Shader msShader = Context.Factory.CompileShader(shader, ShaderStages.Miss, "MissMain", ref reflection);
-        using Shader chShader = Context.Factory.CompileShader(shader, ShaderStages.ClosestHit, "ClosestHitMain", ref reflection);
-        using Shader msAoShader = Context.Factory.CompileShader(shader, ShaderStages.Miss, "MissAO", ref reflection);
-        using Shader chAoShader = Context.Factory.CompileShader(shader, ShaderStages.ClosestHit, "ClosestHitAO", ref reflection);
+        using Shader rgShader = Context.Factory.CompileShader(shader, ShaderStages.RayGeneration, "RayGenMain", out ShaderReflection rgReflection);
+        using Shader msShader = Context.Factory.CompileShader(shader, ShaderStages.Miss, "MissMain", out ShaderReflection msReflection);
+        using Shader chShader = Context.Factory.CompileShader(shader, ShaderStages.ClosestHit, "ClosestHitMain", out ShaderReflection chReflection);
+        using Shader msAoShader = Context.Factory.CompileShader(shader, ShaderStages.Miss, "MissAO", out ShaderReflection msAoReflection);
+        using Shader chAoShader = Context.Factory.CompileShader(shader, ShaderStages.ClosestHit, "ClosestHitAO", out ShaderReflection chAoReflection);
+        ShaderReflection reflection = ShaderReflection.Merge(rgReflection, msReflection, chReflection, msAoReflection, chAoReflection);
 
         ResourceLayoutDesc layoutDesc = new
         (

--- a/src/Examples/RayTracing/RayTracingTest.cs
+++ b/src/Examples/RayTracing/RayTracingTest.cs
@@ -91,9 +91,9 @@ internal unsafe class RayTracingTest() : VisualTest("RayTracing Test")
     private Buffer? materialsBuffer;
     private Buffer? globalBuffer;
     private Texture? output;
-    private ResourceLayout? resLayout;
-    private ResourceSet? resSet;
-    private RayTracingPipeline rtPipeline = null!;
+    private ResourceLayout? layout;
+    private ResourceSet? set;
+    private RayTracingPipeline pipeline = null!;
 
     private Global global;
     private int globalHash;
@@ -201,7 +201,7 @@ internal unsafe class RayTracingTest() : VisualTest("RayTracing Test")
         using Shader msAoShader = Context.Factory.CompileShader(shader, ShaderStages.Miss, "MissAO", ref reflection);
         using Shader chAoShader = Context.Factory.CompileShader(shader, ShaderStages.ClosestHit, "ClosestHitAO", ref reflection);
 
-        ResourceLayoutDesc resLayoutDesc = new
+        ResourceLayoutDesc layoutDesc = new
         (
             reflection["scene"].Desc,
             reflection["vertexBuffers"].Desc,
@@ -211,9 +211,9 @@ internal unsafe class RayTracingTest() : VisualTest("RayTracing Test")
             reflection["output"].Desc
         );
 
-        resLayout = Context.Factory.CreateResourceLayout(in resLayoutDesc);
+        layout = Context.Factory.CreateResourceLayout(in layoutDesc);
 
-        ResourceSetDesc resSetDesc = new(resLayout,
+        ResourceSetDesc setDesc = new(layout,
         [
             tlas,
             .. vertexBuffers,
@@ -223,9 +223,9 @@ internal unsafe class RayTracingTest() : VisualTest("RayTracing Test")
             output
         ]);
 
-        resSet = Context.Factory.CreateResourceSet(in resSetDesc);
+        set = Context.Factory.CreateResourceSet(in setDesc);
 
-        RayTracingPipelineDesc rtpDesc = new
+        RayTracingPipelineDesc pipelineDesc = new
         (
             shaders: new(rgShader, [msShader, msAoShader], [chShader, chAoShader]),
             hitGroups:
@@ -233,10 +233,10 @@ internal unsafe class RayTracingTest() : VisualTest("RayTracing Test")
                 new("DefaultHitGroup", closestHit: "ClosestHitMain"),
                 new("AoHitGroup", closestHit: "ClosestHitAO")
             ],
-            resourceLayouts: [resLayout]
+            resourceLayouts: [layout]
         );
 
-        rtPipeline = Context.Factory.CreateRayTracingPipeline(in rtpDesc);
+        pipeline = Context.Factory.CreateRayTracingPipeline(in pipelineDesc);
 
         CameraController.Transform(Matrix4X4.CreateTranslation(278.000f, 273.000f, -800.000f));
         CameraController.FarPlane = 2400.000f;
@@ -311,10 +311,10 @@ internal unsafe class RayTracingTest() : VisualTest("RayTracing Test")
 
         commandBuffer.Begin();
 
-        commandBuffer.PrepareResources([resSet!]);
+        commandBuffer.PrepareResources([set!]);
 
-        commandBuffer.SetRayTracingPipeline(rtPipeline);
-        commandBuffer.SetResourceSet(0, resSet!);
+        commandBuffer.SetRayTracingPipeline(pipeline);
+        commandBuffer.SetResourceSet(0, set!);
 
         commandBuffer.DispatchRays(Width, Height, 1);
 
@@ -329,7 +329,7 @@ internal unsafe class RayTracingTest() : VisualTest("RayTracing Test")
             ImGuiController.RemoveBinding(output);
         }
 
-        resSet?.Dispose();
+        set?.Dispose();
         output?.Dispose();
 
         TextureDesc outputDesc = new(width,
@@ -338,7 +338,7 @@ internal unsafe class RayTracingTest() : VisualTest("RayTracing Test")
 
         output = Context.Factory.CreateTexture(in outputDesc);
 
-        ResourceSetDesc resSetDesc = new(resLayout!,
+        ResourceSetDesc resSetDesc = new(layout!,
         [
             tlas!,
             .. vertexBuffers,
@@ -348,16 +348,16 @@ internal unsafe class RayTracingTest() : VisualTest("RayTracing Test")
             output
         ]);
 
-        resSet = Context.Factory.CreateResourceSet(in resSetDesc);
+        set = Context.Factory.CreateResourceSet(in resSetDesc);
 
         global.FrameNumber = 0;
     }
 
     protected override void OnDestroy()
     {
-        rtPipeline.Dispose();
-        resSet?.Dispose();
-        resLayout?.Dispose();
+        pipeline.Dispose();
+        set?.Dispose();
+        layout?.Dispose();
         output?.Dispose();
         globalBuffer?.Dispose();
         materialsBuffer?.Dispose();

--- a/src/Examples/Triangle/Assets/Shaders/Shader.slang
+++ b/src/Examples/Triangle/Assets/Shaders/Shader.slang
@@ -1,9 +1,4 @@
-﻿struct Constants
-{
-    float4x4 Model;
-};
-
-struct VertexInput
+﻿struct VertexInput
 {
     float3 Position : POSITION;
 
@@ -21,7 +16,12 @@ struct VertexOutput
     float2 TexCoord : TEXCOORD0;
 };
 
-ConstantBuffer<Constants> constants : register(b0, space0);
+struct Constants
+{
+    float4x4 Model;
+};
+
+uniform Constants constants;
 
 VertexOutput VertexMain(VertexInput input)
 {

--- a/src/Examples/Triangle/TriangleTest.cs
+++ b/src/Examples/Triangle/TriangleTest.cs
@@ -67,9 +67,9 @@ internal unsafe class TriangleTest() : VisualTest("Triangle Test")
 
         Context.UpdateBuffer(constantsBuffer, (nint)(&constants), (uint)sizeof(Constants));
 
-        ShaderReflection reflection = ShaderReflection.Empty;
-        using Shader vsShader = Context.Factory.CompileShader(shader, ShaderStages.Vertex, "VertexMain", ref reflection);
-        using Shader psShader = Context.Factory.CompileShader(shader, ShaderStages.Pixel, "PixelMain", ref reflection);
+        using Shader vsShader = Context.Factory.CompileShader(shader, ShaderStages.Vertex, "VertexMain", out ShaderReflection vsReflection);
+        using Shader psShader = Context.Factory.CompileShader(shader, ShaderStages.Pixel, "PixelMain", out ShaderReflection psReflection);
+        ShaderReflection reflection = ShaderReflection.Merge(vsReflection, psReflection);
 
         ResourceLayoutDesc layoutDesc = new(reflection["constants"].Desc);
 

--- a/src/Examples/Triangle/TriangleTest.cs
+++ b/src/Examples/Triangle/TriangleTest.cs
@@ -71,7 +71,7 @@ internal unsafe class TriangleTest() : VisualTest("Triangle Test")
         using Shader vsShader = Context.Factory.CompileShader(shader, ShaderStages.Vertex, "VertexMain", ref reflection);
         using Shader psShader = Context.Factory.CompileShader(shader, ShaderStages.Pixel, "PixelMain", ref reflection);
 
-        ResourceLayoutDesc layoutDesc = new([reflection["constants"].Desc]);
+        ResourceLayoutDesc layoutDesc = new(reflection["constants"].Desc);
 
         layout = Context.Factory.CreateResourceLayout(in layoutDesc);
 

--- a/src/Examples/Triangle/TriangleTest.cs
+++ b/src/Examples/Triangle/TriangleTest.cs
@@ -67,7 +67,7 @@ internal unsafe class TriangleTest() : VisualTest("Triangle Test")
 
         Context.UpdateBuffer(constantsBuffer, (nint)(&constants), (uint)sizeof(Constants));
 
-        using Shader vsShader = Context.Factory.CompileShader(shader, ShaderStages.Vertex, "VertexMain", out _);
+        using Shader vsShader = Context.Factory.CompileShader(shader, ShaderStages.Vertex, "VertexMain", out ShaderReflection reflection);
         using Shader psShader = Context.Factory.CompileShader(shader, ShaderStages.Pixel, "PixelMain", out _);
 
         ResourceLayoutDesc layoutDesc = new([new(ShaderStages.Vertex, ResourceType.ConstantBuffer, 0)]);

--- a/src/Examples/Triangle/TriangleTest.cs
+++ b/src/Examples/Triangle/TriangleTest.cs
@@ -71,7 +71,7 @@ internal unsafe class TriangleTest() : VisualTest("Triangle Test")
         using Shader vsShader = Context.Factory.CompileShader(shader, ShaderStages.Vertex, "VertexMain", ref reflection);
         using Shader psShader = Context.Factory.CompileShader(shader, ShaderStages.Pixel, "PixelMain", ref reflection);
 
-        ResourceLayoutDesc layoutDesc = new([new(ShaderStages.Vertex, ResourceType.ConstantBuffer, 0)]);
+        ResourceLayoutDesc layoutDesc = new([reflection["constants"].Desc]);
 
         layout = Context.Factory.CreateResourceLayout(in layoutDesc);
 

--- a/src/Examples/Triangle/TriangleTest.cs
+++ b/src/Examples/Triangle/TriangleTest.cs
@@ -67,8 +67,8 @@ internal unsafe class TriangleTest() : VisualTest("Triangle Test")
 
         Context.UpdateBuffer(constantsBuffer, (nint)(&constants), (uint)sizeof(Constants));
 
-        using Shader vsShader = Context.Factory.CompileShader(shader, ShaderStages.Vertex, "VertexMain");
-        using Shader psShader = Context.Factory.CompileShader(shader, ShaderStages.Pixel, "PixelMain");
+        using Shader vsShader = Context.Factory.CompileShader(shader, ShaderStages.Vertex, "VertexMain", out _);
+        using Shader psShader = Context.Factory.CompileShader(shader, ShaderStages.Pixel, "PixelMain", out _);
 
         ResourceLayoutDesc layoutDesc = new([new(ShaderStages.Vertex, ResourceType.ConstantBuffer, 0)]);
 

--- a/src/Examples/Triangle/TriangleTest.cs
+++ b/src/Examples/Triangle/TriangleTest.cs
@@ -67,8 +67,9 @@ internal unsafe class TriangleTest() : VisualTest("Triangle Test")
 
         Context.UpdateBuffer(constantsBuffer, (nint)(&constants), (uint)sizeof(Constants));
 
-        using Shader vsShader = Context.Factory.CompileShader(shader, ShaderStages.Vertex, "VertexMain", out ShaderReflection reflection);
-        using Shader psShader = Context.Factory.CompileShader(shader, ShaderStages.Pixel, "PixelMain", out _);
+        ShaderReflection reflection = ShaderReflection.Empty;
+        using Shader vsShader = Context.Factory.CompileShader(shader, ShaderStages.Vertex, "VertexMain", ref reflection);
+        using Shader psShader = Context.Factory.CompileShader(shader, ShaderStages.Pixel, "PixelMain", ref reflection);
 
         ResourceLayoutDesc layoutDesc = new([new(ShaderStages.Vertex, ResourceType.ConstantBuffer, 0)]);
 

--- a/src/ZenithEngine.ShaderCompiler/ResourceFactoryExtensions.cs
+++ b/src/ZenithEngine.ShaderCompiler/ResourceFactoryExtensions.cs
@@ -11,7 +11,8 @@ public static class ResourceFactoryExtensions
     public static Shader CompileShader(this ResourceFactory factory,
                                        string path,
                                        ShaderStages stage,
-                                       string entryPoint)
+                                       string entryPoint,
+                                       out ShaderReflection reflection)
     {
         List<string> arguments =
         [
@@ -41,7 +42,9 @@ public static class ResourceFactoryExtensions
                 throw new ZenithEngineException(ExceptionHelpers.NotSupported(factory.Context.Backend));
         }
 
-        byte[] shaderBytes = SlangCompiler.CompileWithReflection([.. arguments], out _);
+        byte[] shaderBytes = SlangCompiler.CompileWithReflection([.. arguments], out SlangReflection slangReflection);
+
+        reflection = new(slangReflection);
 
         ShaderDesc shaderDesc = new(stage, shaderBytes, entryPoint);
 

--- a/src/ZenithEngine.ShaderCompiler/ResourceFactoryExtensions.cs
+++ b/src/ZenithEngine.ShaderCompiler/ResourceFactoryExtensions.cs
@@ -12,7 +12,7 @@ public static class ResourceFactoryExtensions
                                        string path,
                                        ShaderStages stage,
                                        string entryPoint,
-                                       out ShaderReflection reflection)
+                                       ref ShaderReflection reflection)
     {
         List<string> arguments =
         [
@@ -44,7 +44,7 @@ public static class ResourceFactoryExtensions
 
         byte[] shaderBytes = SlangCompiler.CompileWithReflection([.. arguments], out SlangReflection slangReflection);
 
-        reflection = new(stage, slangReflection);
+        reflection = new(reflection, new(stage, slangReflection));
 
         ShaderDesc shaderDesc = new(stage, shaderBytes, entryPoint);
 

--- a/src/ZenithEngine.ShaderCompiler/ResourceFactoryExtensions.cs
+++ b/src/ZenithEngine.ShaderCompiler/ResourceFactoryExtensions.cs
@@ -44,7 +44,7 @@ public static class ResourceFactoryExtensions
 
         byte[] shaderBytes = SlangCompiler.CompileWithReflection([.. arguments], out SlangReflection slangReflection);
 
-        reflection = new(slangReflection);
+        reflection = new(stage, slangReflection);
 
         ShaderDesc shaderDesc = new(stage, shaderBytes, entryPoint);
 

--- a/src/ZenithEngine.ShaderCompiler/ShaderBinding.cs
+++ b/src/ZenithEngine.ShaderCompiler/ShaderBinding.cs
@@ -1,0 +1,10 @@
+﻿using ZenithEngine.Common.Descriptions;
+
+namespace ZenithEngine.ShaderCompiler;
+
+public readonly struct ShaderBinding(uint space, ResourceElementDesc desc)
+{
+    public uint Space { get; } = space;
+
+    public ResourceElementDesc Desc { get; } = desc;
+}

--- a/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
+++ b/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
@@ -1,0 +1,19 @@
+﻿using Slangc.NET;
+
+namespace ZenithEngine.ShaderCompiler;
+
+public class ShaderReflection
+{
+    internal ShaderReflection(SlangReflection slangReflection)
+    {
+    }
+
+    internal ShaderReflection(ShaderReflection[] reflections)
+    {
+    }
+
+    public ShaderReflection Merge(ShaderReflection other)
+    {
+        return new ShaderReflection([this, other]);
+    }
+}

--- a/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
+++ b/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
@@ -64,7 +64,7 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
         cache = new(bindings);
     }
 
-    internal ShaderReflection(params ShaderReflection[] reflections)
+    internal ShaderReflection(ShaderReflection[] reflections)
     {
         Dictionary<string, ShaderBinding> bindings = [];
         foreach (ShaderReflection reflection in reflections)
@@ -93,8 +93,6 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
 
         cache = new(bindings);
     }
-
-    public static ShaderReflection Empty => new();
 
     public ShaderBinding this[string key] => cache[key];
 
@@ -140,6 +138,11 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
         }
 
         return resourceLayoutDescs;
+    }
+
+    public static ShaderReflection Merge(params ShaderReflection[] reflections)
+    {
+        return new(reflections);
     }
 
     private static void ParseParameterBlock(string name,

--- a/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
+++ b/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
@@ -44,7 +44,7 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
                 ResourceElementDesc desc = new(stage,
                                                GetResourceType(binding.Kind, parameter.Type),
                                                binding.Index,
-                                               binding.Count);
+                                               GetCount(binding, parameter.Type));
 
                 bindings.Add(namedTypeBinding.Name, new(binding.Space, desc));
             }
@@ -163,7 +163,7 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
                 ResourceElementDesc desc = new(stage,
                                                GetResourceType(var.Binding!.Kind, var.Type),
                                                var.Binding.Index,
-                                               var.Binding.Count);
+                                               GetCount(var.Binding, var.Type));
 
                 bindings.Add(varName, new(var.Binding.Space, desc));
             }
@@ -216,5 +216,14 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
                 _ => throw new ZenithEngineException(ExceptionHelpers.NotSupported(type.Resource.BaseShape))
             };
         }
+    }
+
+    private static uint GetCount(SlangBinding binding, SlangType type)
+    {
+        return type.Kind switch
+        {
+            SlangTypeKind.Array => type.Array!.ElementCount,
+            _ => binding.Count
+        };
     }
 }

--- a/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
+++ b/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
@@ -12,7 +12,7 @@ namespace ZenithEngine.ShaderCompiler;
 
 public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
 {
-    private readonly ReadOnlyDictionary<string, ShaderBinding> bindings;
+    private readonly ReadOnlyDictionary<string, ShaderBinding> cache;
 
     internal ShaderReflection(ShaderStages stage, SlangReflection slangReflection)
     {
@@ -61,7 +61,7 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
             space++;
         }
 
-        this.bindings = new(bindings);
+        cache = new(bindings);
     }
 
     internal ShaderReflection(ShaderReflection[] reflections)
@@ -69,7 +69,7 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
         Dictionary<string, ShaderBinding> bindings = [];
         foreach (ShaderReflection reflection in reflections)
         {
-            foreach (KeyValuePair<string, ShaderBinding> binding in reflection.bindings)
+            foreach (KeyValuePair<string, ShaderBinding> binding in reflection.cache)
             {
                 if (!bindings.TryGetValue(binding.Key, out ShaderBinding value))
                 {
@@ -91,30 +91,30 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
             }
         }
 
-        this.bindings = new(bindings);
+        cache = new(bindings);
     }
 
-    public ShaderBinding this[string key] => bindings[key];
+    public ShaderBinding this[string key] => cache[key];
 
-    public IEnumerable<string> Keys => bindings.Keys;
+    public IEnumerable<string> Keys => cache.Keys;
 
-    public IEnumerable<ShaderBinding> Values => bindings.Values;
+    public IEnumerable<ShaderBinding> Values => cache.Values;
 
-    public int Count => bindings.Count;
+    public int Count => cache.Count;
 
     public bool ContainsKey(string key)
     {
-        return bindings.ContainsKey(key);
+        return cache.ContainsKey(key);
     }
 
     public IEnumerator<KeyValuePair<string, ShaderBinding>> GetEnumerator()
     {
-        return bindings.GetEnumerator();
+        return cache.GetEnumerator();
     }
 
     public bool TryGetValue(string key, [MaybeNullWhen(false)] out ShaderBinding value)
     {
-        return bindings.TryGetValue(key, out value);
+        return cache.TryGetValue(key, out value);
     }
 
     IEnumerator IEnumerable.GetEnumerator()
@@ -129,7 +129,7 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
 
     public ResourceLayoutDesc[] ToResourceLayoutDescs()
     {
-        uint[] spaces = [.. bindings.Values.Select(static item => item.Space).Distinct()];
+        uint[] spaces = [.. cache.Values.Select(static item => item.Space).Distinct()];
 
         ResourceLayoutDesc[] resourceLayoutDescs = new ResourceLayoutDesc[spaces.Length];
 
@@ -137,7 +137,7 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
         {
             uint space = spaces[i];
 
-            ResourceElementDesc[] elements = [.. bindings.Values.Where(item => item.Space == space).Select(static item => item.Desc)];
+            ResourceElementDesc[] elements = [.. cache.Values.Where(item => item.Space == space).Select(static item => item.Desc)];
 
             resourceLayoutDescs[i] = new(elements);
         }

--- a/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
+++ b/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
@@ -64,7 +64,7 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
         cache = new(bindings);
     }
 
-    internal ShaderReflection(ShaderReflection[] reflections)
+    internal ShaderReflection(params ShaderReflection[] reflections)
     {
         Dictionary<string, ShaderBinding> bindings = [];
         foreach (ShaderReflection reflection in reflections)
@@ -94,6 +94,8 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
         cache = new(bindings);
     }
 
+    public static ShaderReflection Empty => new();
+
     public ShaderBinding this[string key] => cache[key];
 
     public IEnumerable<string> Keys => cache.Keys;
@@ -120,11 +122,6 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
     IEnumerator IEnumerable.GetEnumerator()
     {
         return GetEnumerator();
-    }
-
-    public ShaderReflection Merge(ShaderReflection other)
-    {
-        return new ShaderReflection([this, other]);
     }
 
     public ResourceLayoutDesc[] ToResourceLayoutDescs()

--- a/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
+++ b/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
@@ -46,15 +46,15 @@ public class ShaderReflection
             }
         }
 
-        uint space = 0;
-        foreach (uint item in bindings.Values.Select(static item => item.Space).Distinct())
+        uint expectedSpace = 0;
+        foreach (uint space in bindings.Values.Select(static item => item.Space).Distinct())
         {
-            if (item != space)
+            if (space != expectedSpace)
             {
                 throw new ZenithEngineException("The space of the resource is not continuous.");
             }
 
-            space++;
+            expectedSpace++;
         }
 
         Bindings = new(bindings);

--- a/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
+++ b/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
@@ -1,11 +1,46 @@
 ﻿using Slangc.NET;
+using Slangc.NET.Enums;
+using Slangc.NET.Models;
+using ZenithEngine.Common;
+using ZenithEngine.Common.Enums;
 
 namespace ZenithEngine.ShaderCompiler;
 
 public class ShaderReflection
 {
-    internal ShaderReflection(SlangReflection slangReflection)
+    private record ShaderBinding(string Name, ShaderStages Stages, ResourceType type, uint Space, uint Index, uint Count);
+
+    private readonly Dictionary<string, ShaderBinding> bindings = [];
+
+    internal ShaderReflection(ShaderStages stage, SlangReflection slangReflection)
     {
+        SlangEntryPoint entryPoint = slangReflection.EntryPoints[0];
+
+        foreach (SlangNamedTypeBinding namedTypeBinding in entryPoint.Bindings)
+        {
+            SlangBinding binding = namedTypeBinding.Binding;
+
+            //if (!binding.Used)
+            //{
+            //    continue;
+            //}
+
+            if (binding.Kind is SlangParameterCategory.SubElementRegisterSpace)
+            {
+                // 递归结构体。
+            }
+            else
+            {
+                SlangParameter parameter = slangReflection.Parameters.First(item => item.Name == namedTypeBinding.Name);
+
+                bindings.Add(namedTypeBinding.Name, new(namedTypeBinding.Name,
+                                                        stage,
+                                                        GetResourceType(binding.Kind, parameter.Type),
+                                                        binding.Space,
+                                                        binding.Index,
+                                                        binding.Count));
+            }
+        }
     }
 
     internal ShaderReflection(ShaderReflection[] reflections)
@@ -15,5 +50,49 @@ public class ShaderReflection
     public ShaderReflection Merge(ShaderReflection other)
     {
         return new ShaderReflection([this, other]);
+    }
+
+    private static ResourceType GetResourceType(SlangParameterCategory parameterCategory, SlangType type)
+    {
+        return parameterCategory switch
+        {
+            SlangParameterCategory.ConstantBuffer or
+            SlangParameterCategory.Uniform => ResourceType.ConstantBuffer,
+
+            SlangParameterCategory.SamplerState => ResourceType.Sampler,
+
+            SlangParameterCategory.ShaderResource => ResourceCategory(type, false),
+
+            SlangParameterCategory.UnorderedAccess => ResourceCategory(type, true),
+
+            _ => throw new ZenithEngineException(ExceptionHelpers.NotSupported(parameterCategory))
+        };
+
+        static ResourceType ResourceCategory(SlangType type, bool isReadWrite)
+        {
+            if (type.Kind is SlangTypeKind.Array)
+            {
+                return ResourceCategory(type.Array!.ElementType, isReadWrite);
+            }
+
+            if (type.Kind is not SlangTypeKind.Resource)
+            {
+                throw new ZenithEngineException(ExceptionHelpers.NotSupported(type.Kind));
+            }
+
+            return type.Resource!.BaseShape switch
+            {
+                SlangResourceShape.Texture1D or
+                SlangResourceShape.Texture2D or
+                SlangResourceShape.Texture3D or
+                SlangResourceShape.TextureCube => isReadWrite ? ResourceType.TextureReadWrite : ResourceType.Texture,
+
+                SlangResourceShape.StructuredBuffer => isReadWrite ? ResourceType.StructuredBufferReadWrite : ResourceType.StructuredBuffer,
+
+                SlangResourceShape.AccelerationStructure => ResourceType.AccelerationStructure,
+
+                _ => throw new ZenithEngineException(ExceptionHelpers.NotSupported(type.Resource.BaseShape)),
+            };
+        }
     }
 }

--- a/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
+++ b/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
@@ -42,9 +42,9 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
             else
             {
                 ResourceElementDesc desc = new(stage,
-                                               GetResourceType(binding.Kind, parameter.Type),
+                                               GetType(binding.Kind, parameter.Type),
                                                binding.Index,
-                                               GetCount(binding, parameter.Type));
+                                               GetCount(parameter.Type, binding.Count));
 
                 bindings.Add(namedTypeBinding.Name, new(binding.Space, desc));
             }
@@ -161,29 +161,25 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
             else
             {
                 ResourceElementDesc desc = new(stage,
-                                               GetResourceType(var.Binding!.Kind, var.Type),
+                                               GetType(var.Binding!.Kind, var.Type),
                                                var.Binding.Index,
-                                               GetCount(var.Binding, var.Type));
+                                               GetCount(var.Type, var.Binding.Count));
 
                 bindings.Add(varName, new(var.Binding.Space, desc));
             }
         }
     }
 
-    private static ResourceType GetResourceType(SlangParameterCategory parameterCategory, SlangType type)
+    private static ResourceType GetType(SlangParameterCategory kind, SlangType type)
     {
-        return parameterCategory switch
+        return kind switch
         {
             SlangParameterCategory.ConstantBuffer or
             SlangParameterCategory.Uniform => ResourceType.ConstantBuffer,
 
             SlangParameterCategory.SamplerState => ResourceType.Sampler,
 
-            SlangParameterCategory.ShaderResource or
-            SlangParameterCategory.UnorderedAccess or
-            SlangParameterCategory.DescriptorTableSlot => Indistinct(type),
-
-            _ => throw new ZenithEngineException(ExceptionHelpers.NotSupported(parameterCategory))
+            _ => Indistinct(type)
         };
 
         static ResourceType Indistinct(SlangType type)
@@ -218,12 +214,12 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
         }
     }
 
-    private static uint GetCount(SlangBinding binding, SlangType type)
+    private static uint GetCount(SlangType type, uint defaultCount)
     {
         return type.Kind switch
         {
             SlangTypeKind.Array => type.Array!.ElementCount,
-            _ => binding.Count
+            _ => defaultCount
         };
     }
 }

--- a/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
+++ b/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
@@ -96,20 +96,14 @@ public class ShaderReflection
 
     public ResourceLayoutDesc[] ToResourceLayoutDescs()
     {
-        uint[] spaces = [.. Bindings.Values.Select(static item => item.Space).Distinct()];
+        List<ResourceLayoutDesc> resourceLayoutDescs = [];
 
-        ResourceLayoutDesc[] resourceLayoutDescs = new ResourceLayoutDesc[spaces.Length];
-
-        for (int i = 0; i < spaces.Length; i++)
+        foreach (uint space in Bindings.Values.Select(static item => item.Space).Distinct())
         {
-            uint space = spaces[i];
-
-            ResourceElementDesc[] elements = [.. Bindings.Values.Where(item => item.Space == space).Select(static item => item.Desc)];
-
-            resourceLayoutDescs[i] = new(elements);
+            resourceLayoutDescs.Add(new([.. Bindings.Values.Where(item => item.Space == space).Select(static item => item.Desc)]));
         }
 
-        return resourceLayoutDescs;
+        return [.. resourceLayoutDescs];
     }
 
     public static ShaderReflection Merge(params ShaderReflection[] reflections)

--- a/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
+++ b/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
@@ -1,4 +1,5 @@
-﻿using Slangc.NET;
+﻿using System.Collections.ObjectModel;
+using Slangc.NET;
 using Slangc.NET.Enums;
 using Slangc.NET.Models;
 using ZenithEngine.Common;
@@ -8,31 +9,38 @@ namespace ZenithEngine.ShaderCompiler;
 
 public class ShaderReflection
 {
-    private record ShaderBinding(string Name, ShaderStages Stages, ResourceType type, uint Space, uint Index, uint Count);
+    private record ShaderBinding(string Name, ShaderStages Stages, ResourceType Type, uint Space, uint Index, uint Count);
 
-    private readonly Dictionary<string, ShaderBinding> bindings = [];
+    private readonly ReadOnlyDictionary<string, ShaderBinding> cache;
 
     internal ShaderReflection(ShaderStages stage, SlangReflection slangReflection)
     {
         SlangEntryPoint entryPoint = slangReflection.EntryPoints[0];
 
+        Dictionary<string, ShaderBinding> bindings = [];
+
         foreach (SlangNamedTypeBinding namedTypeBinding in entryPoint.Bindings)
         {
             SlangBinding binding = namedTypeBinding.Binding;
 
-            //if (!binding.Used)
-            //{
-            //    continue;
-            //}
+            if (!binding.Used)
+            {
+                continue;
+            }
+
+            SlangParameter parameter = slangReflection.Parameters.First(item => item.Name == namedTypeBinding.Name);
 
             if (binding.Kind is SlangParameterCategory.SubElementRegisterSpace)
             {
-                // 递归结构体。
+                if (parameter.Type.Kind is not SlangTypeKind.ParameterBlock)
+                {
+                    throw new ZenithEngineException(ExceptionHelpers.NotSupported(parameter.Type.Kind));
+                }
+
+                ParseParameterBlock(namedTypeBinding.Name, stage, bindings, parameter.Type);
             }
             else
             {
-                SlangParameter parameter = slangReflection.Parameters.First(item => item.Name == namedTypeBinding.Name);
-
                 bindings.Add(namedTypeBinding.Name, new(namedTypeBinding.Name,
                                                         stage,
                                                         GetResourceType(binding.Kind, parameter.Type),
@@ -41,15 +49,64 @@ public class ShaderReflection
                                                         binding.Count));
             }
         }
+
+        cache = new(bindings);
     }
 
     internal ShaderReflection(ShaderReflection[] reflections)
     {
+        Dictionary<string, ShaderBinding> bindings = [];
+
+        foreach (ShaderReflection reflection in reflections)
+        {
+            foreach (KeyValuePair<string, ShaderBinding> binding in reflection.cache)
+            {
+                if (!bindings.TryGetValue(binding.Key, out ShaderBinding? value))
+                {
+                    bindings.Add(binding.Key, binding.Value);
+                }
+                else
+                {
+                    ShaderStages stages = value.Stages | binding.Value.Stages;
+
+                    bindings[binding.Key] = new(binding.Value.Name,
+                                                stages,
+                                                binding.Value.Type,
+                                                binding.Value.Space,
+                                                binding.Value.Index,
+                                                binding.Value.Count);
+                }
+            }
+        }
+
+        cache = new(bindings);
     }
 
     public ShaderReflection Merge(ShaderReflection other)
     {
         return new ShaderReflection([this, other]);
+    }
+
+    private static void ParseParameterBlock(string name, ShaderStages stage, Dictionary<string, ShaderBinding> bindings, SlangType type)
+    {
+        foreach (SlangVar var in type.ParameterBlock!.ElementType.Struct!.Fields)
+        {
+            string varName = $"{name}.{var.Name}";
+
+            if (var.Type.Kind is SlangTypeKind.ParameterBlock)
+            {
+                ParseParameterBlock(varName, stage, bindings, var.Type);
+            }
+            else
+            {
+                bindings.Add(varName, new(varName,
+                                          stage,
+                                          GetResourceType(var.Binding!.Kind, var.Type),
+                                          var.Binding.Space,
+                                          var.Binding.Index,
+                                          var.Binding.Count));
+            }
+        }
     }
 
     private static ResourceType GetResourceType(SlangParameterCategory parameterCategory, SlangType type)
@@ -61,24 +118,28 @@ public class ShaderReflection
 
             SlangParameterCategory.SamplerState => ResourceType.Sampler,
 
-            SlangParameterCategory.ShaderResource => ResourceCategory(type, false),
-
-            SlangParameterCategory.UnorderedAccess => ResourceCategory(type, true),
+            SlangParameterCategory.ShaderResource or
+            SlangParameterCategory.UnorderedAccess or
+            SlangParameterCategory.DescriptorTableSlot => Indistinct(type),
 
             _ => throw new ZenithEngineException(ExceptionHelpers.NotSupported(parameterCategory))
         };
 
-        static ResourceType ResourceCategory(SlangType type, bool isReadWrite)
+        static ResourceType Indistinct(SlangType type)
         {
-            if (type.Kind is SlangTypeKind.Array)
+            return type.Kind switch
             {
-                return ResourceCategory(type.Array!.ElementType, isReadWrite);
-            }
+                SlangTypeKind.Array => Indistinct(type.Array!.ElementType),
+                SlangTypeKind.ConstantBuffer => ResourceType.ConstantBuffer,
+                SlangTypeKind.Resource => Resource(type),
+                SlangTypeKind.SamplerState => ResourceType.Sampler,
+                _ => throw new ZenithEngineException(ExceptionHelpers.NotSupported(type.Kind))
+            };
+        }
 
-            if (type.Kind is not SlangTypeKind.Resource)
-            {
-                throw new ZenithEngineException(ExceptionHelpers.NotSupported(type.Kind));
-            }
+        static ResourceType Resource(SlangType type)
+        {
+            bool isReadWrite = type.Resource!.Access is SlangResourceAccess.ReadWrite;
 
             return type.Resource!.BaseShape switch
             {
@@ -91,7 +152,7 @@ public class ShaderReflection
 
                 SlangResourceShape.AccelerationStructure => ResourceType.AccelerationStructure,
 
-                _ => throw new ZenithEngineException(ExceptionHelpers.NotSupported(type.Resource.BaseShape)),
+                _ => throw new ZenithEngineException(ExceptionHelpers.NotSupported(type.Resource.BaseShape))
             };
         }
     }

--- a/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
+++ b/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
@@ -3,6 +3,7 @@ using Slangc.NET;
 using Slangc.NET.Enums;
 using Slangc.NET.Models;
 using ZenithEngine.Common;
+using ZenithEngine.Common.Descriptions;
 using ZenithEngine.Common.Enums;
 
 namespace ZenithEngine.ShaderCompiler;
@@ -80,6 +81,19 @@ public class ShaderReflection
         }
 
         cache = new(bindings);
+    }
+
+    public ResourceElementDesc this[string name]
+    {
+        get
+        {
+            if (!cache.TryGetValue(name, out ShaderBinding? binding))
+            {
+                throw new ZenithEngineException($"The shader resource `{name}` is not found.");
+            }
+
+            return new(binding.Stages, binding.Type, binding.Index, binding.Count);
+        }
     }
 
     public ShaderReflection Merge(ShaderReflection other)

--- a/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
+++ b/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
@@ -129,7 +129,20 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
 
     public ResourceLayoutDesc[] ToResourceLayoutDescs()
     {
-        throw new NotImplementedException();
+        uint[] spaces = [.. bindings.Values.Select(static item => item.Space).Distinct()];
+
+        ResourceLayoutDesc[] resourceLayoutDescs = new ResourceLayoutDesc[spaces.Length];
+
+        for (int i = 0; i < spaces.Length; i++)
+        {
+            uint space = spaces[i];
+
+            ResourceElementDesc[] elements = [.. bindings.Values.Where(item => item.Space == space).Select(static item => item.Desc)];
+
+            resourceLayoutDescs[i] = new(elements);
+        }
+
+        return resourceLayoutDescs;
     }
 
     private static void ParseParameterBlock(string name,

--- a/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
+++ b/src/ZenithEngine.ShaderCompiler/ShaderReflection.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.ObjectModel;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.ObjectModel;
 using Slangc.NET;
 using Slangc.NET.Enums;
 using Slangc.NET.Models;
@@ -10,10 +8,8 @@ using ZenithEngine.Common.Enums;
 
 namespace ZenithEngine.ShaderCompiler;
 
-public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
+public class ShaderReflection
 {
-    private readonly ReadOnlyDictionary<string, ShaderBinding> cache;
-
     internal ShaderReflection(ShaderStages stage, SlangReflection slangReflection)
     {
         SlangEntryPoint entryPoint = slangReflection.EntryPoints[0];
@@ -61,7 +57,7 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
             space++;
         }
 
-        cache = new(bindings);
+        Bindings = new(bindings);
     }
 
     internal ShaderReflection(ShaderReflection[] reflections)
@@ -69,7 +65,7 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
         Dictionary<string, ShaderBinding> bindings = [];
         foreach (ShaderReflection reflection in reflections)
         {
-            foreach (KeyValuePair<string, ShaderBinding> binding in reflection.cache)
+            foreach (KeyValuePair<string, ShaderBinding> binding in reflection.Bindings)
             {
                 if (!bindings.TryGetValue(binding.Key, out ShaderBinding value))
                 {
@@ -91,40 +87,16 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
             }
         }
 
-        cache = new(bindings);
+        Bindings = new(bindings);
     }
 
-    public ShaderBinding this[string key] => cache[key];
+    public ReadOnlyDictionary<string, ShaderBinding> Bindings { get; }
 
-    public IEnumerable<string> Keys => cache.Keys;
-
-    public IEnumerable<ShaderBinding> Values => cache.Values;
-
-    public int Count => cache.Count;
-
-    public bool ContainsKey(string key)
-    {
-        return cache.ContainsKey(key);
-    }
-
-    public IEnumerator<KeyValuePair<string, ShaderBinding>> GetEnumerator()
-    {
-        return cache.GetEnumerator();
-    }
-
-    public bool TryGetValue(string key, [MaybeNullWhen(false)] out ShaderBinding value)
-    {
-        return cache.TryGetValue(key, out value);
-    }
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
+    public ShaderBinding this[string key] => Bindings[key];
 
     public ResourceLayoutDesc[] ToResourceLayoutDescs()
     {
-        uint[] spaces = [.. cache.Values.Select(static item => item.Space).Distinct()];
+        uint[] spaces = [.. Bindings.Values.Select(static item => item.Space).Distinct()];
 
         ResourceLayoutDesc[] resourceLayoutDescs = new ResourceLayoutDesc[spaces.Length];
 
@@ -132,7 +104,7 @@ public class ShaderReflection : IReadOnlyDictionary<string, ShaderBinding>
         {
             uint space = spaces[i];
 
-            ResourceElementDesc[] elements = [.. cache.Values.Where(item => item.Space == space).Select(static item => item.Desc)];
+            ResourceElementDesc[] elements = [.. Bindings.Values.Where(item => item.Space == space).Select(static item => item.Desc)];
 
             resourceLayoutDescs[i] = new(elements);
         }


### PR DESCRIPTION
#### PR Classification
新增功能，增强着色器的反射能力和资源管理。

#### PR Summary
本次更新主要集中在增强着色器的反射能力和改进资源管理，更新了相关的着色器编译方法和资源布局。  
- `Shader.slang`: 修改了 `Constants` 结构，添加了 `Model` 属性，并将 `Output` 更名为 `output`。  
- `ComputeShaderTest.cs`: 更新了资源布局和资源集的变量名称，提高了代码可读性。  
- `RayTracingTest.cs`: 重构了资源布局和资源集的创建，使用了新的 `ShaderReflection` 类。  
- `TriangleTest.cs`: 更新了着色器编译方法，增加了反射功能以获取绑定信息。  
- `ResourceFactoryExtensions.cs`: 添加了重载的 `CompileShader` 方法，以支持反射信息的获取。  
